### PR TITLE
Fix for Modbus.Tcp.ModbusServer HandleWriteMultipleRegisters 

### DIFF
--- a/src/Modbus.Tcp/Protocol/Response.cs
+++ b/src/Modbus.Tcp/Protocol/Response.cs
@@ -101,7 +101,7 @@ namespace AMWD.Modbus.Tcp.Protocol
 			var fn = (byte)Function;
 			if (IsError)
 			{
-				fn = (byte)(fn & Consts.ErrorMask);
+				fn = (byte)(fn | Consts.ErrorMask);
 				buffer.AddByte((byte)ErrorCode);
 			}
 			else

--- a/src/Modbus.Tcp/Server/ModbusServer.cs
+++ b/src/Modbus.Tcp/Server/ModbusServer.cs
@@ -812,7 +812,8 @@ namespace AMWD.Modbus.Tcp.Server
 			{
 				var response = new Response(request);
 
-				if (request.Count < Consts.MinCount || request.Count > Consts.MaxRegisterCountWrite || request.Count * 2 != request.Data.Length)
+				//request.Data contains [byte count] [data]..[data]
+				if (request.Count < Consts.MinCount || request.Count > Consts.MaxRegisterCountWrite || request.Count * 2 != request.Data.Length - 1)
 				{
 					response.ErrorCode = ErrorCode.IllegalDataValue;
 				}

--- a/src/Modbus.Tcp/Server/ModbusServer.cs
+++ b/src/Modbus.Tcp/Server/ModbusServer.cs
@@ -829,7 +829,7 @@ namespace AMWD.Modbus.Tcp.Server
 						for (int i = 0; i < request.Count; i++)
 						{
 							var addr = (ushort)(request.Address + i);
-							var val = request.Data.GetUInt16(i * 2);
+							var val = request.Data.GetUInt16(i * 2 + 1);
 
 							var register = new Register { Address = addr, Value = val };
 							SetHoldingRegister(request.DeviceId, register);


### PR DESCRIPTION
Modbus.Tcp.ModbusServer HandleWriteMultipleRegisters always returned IllegalDataValue because of this test: request.Count * 2 != request.Data.Length
request.Data also contains the number of data bytes to follow as the first byte

In Modbus.Tcp.Protocol.Response.Serialze  error code should be function (code | 0x80) on response
